### PR TITLE
Add bold 'hack' to text field

### DIFF
--- a/lib/zebra/zpl/text.rb
+++ b/lib/zebra/zpl/text.rb
@@ -7,7 +7,7 @@ module Zebra
 
       class InvalidMaxLinesError < StandardError; end
 
-      attr_reader :font_size, :font_type, :width, :line_spacing, :hanging_indent
+      attr_reader :font_size, :font_type, :width, :line_spacing, :hanging_indent, :bold
 
       def font_size=(f)
         FontSize.validate_font_size f
@@ -25,6 +25,10 @@ module Zebra
       def max_lines=(value)
         raise InvalidMaxLinesError unless value.to_i >= 1
         @max_lines = value
+      end
+
+      def bold=(value)
+        @bold = value
       end
 
       def line_spacing=(value)
@@ -81,11 +85,12 @@ module Zebra
 
       def to_zpl
         check_attributes
-        # ["A#{x}", y, rotation, font_size, h_multiplier, v_multiplier, print_mode, "\"#{data}\""].join(",")
-        # "^FO25,25^FB600,100,0,C,0^FDFoo^FS"
-
-        # "^CF#{font_type},#{font_size}^FO#{x},#{y}^FB609,4,0,#{justification},0^FD#{data}^FS"
-        "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS"
+        zpl = "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS"
+        if bold.present?
+          zpl += "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x+2},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS" 
+          zpl += "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y+2}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS" 
+        end
+        zpl
       end
 
       private


### PR DESCRIPTION
Previously 
```
label = Zebra::Zpl::Label.new(
    :width         => 800,
    :length        => 1200,
    :print_speed   => 6,
    :print_density => 6
)
fields = []
fields.push Zebra::Zpl::Text.new(
    :data           => "Hello There",
    :position       => [30, 90],
    :font_size      => Zebra::Zpl::FontSize::SIZE_6
)
fields.each { |field| label << field }
label.dump_contents    
 ```

<img width="999" alt="Screen Shot 2019-08-21 at 10 04 06 AM" src="https://user-images.githubusercontent.com/16580125/63439138-82317e00-c3fb-11e9-9ea2-d4d29e7577ef.png">


Now: 

```
label = Zebra::Zpl::Label.new(
    :width         => 800,
    :length        => 1200,
    :print_speed   => 6,
    :print_density => 6
)
fields = []
fields.push Zebra::Zpl::Text.new(
    :data           => "Hello There",
    :position       => [30, 90],
    :font_size      => Zebra::Zpl::FontSize::SIZE_6,
    :bold           => true
)
fields.each { |field| label << field }
label.dump_contents
```
<img width="1017" alt="Screen Shot 2019-08-21 at 10 03 54 AM" src="https://user-images.githubusercontent.com/16580125/63439171-96757b00-c3fb-11e9-99eb-ddf630708904.png">

This is a bit "hacky" as it just writes the text field twice (once in x direction +2, once in y direction +2) but ZPL doesn't really support bold, so it's useful if you don't want to find a different font type or if you don't want to duplicate code multiple times.
